### PR TITLE
Use platform default SDK

### DIFF
--- a/whereami.xcodeproj/project.pbxproj
+++ b/whereami.xcodeproj/project.pbxproj
@@ -197,7 +197,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -208,7 +208,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;


### PR DESCRIPTION
This eliminates failure to build on recent versions of OSX, but (I think..) it should still work on 10.6 etc.
