### PR TITLE
Improve installation step to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ INSTALLATION
 `whereami` comes with batteries included. You just need to clone the project to your local machine, switch to the **swift** branch, and install it using `xcodebuild`/`xctool`. In the near future, I will make that branch the main one, but not just yet.
 
 ```console
-$ git clone git@github.com:victor/whereami.git whereami
+$ git clone https://github.com/victor/whereami.git whereami
 $ cd whereami
 $ git checkout swift
 $ xctool install


### PR DESCRIPTION
Using `https://` is easier that `git@` for public installations, because there's no password prompt.
